### PR TITLE
[sc-156999] allow proxy info to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ GitHub Action for evaluating LaunchDarkly flags in your workflow.
 
 ## Configuration
 
-| Option       | Description                                                                                  | Required | Default value                     |
-| ------------ | -------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
-| `sdk-key`    | SDK Key for environment                                                                      | true     |                                   |
-| `flag-keys`  | The flag keys to evaluate                                                                    | true     |                                   |
-| `user-key`   | The key of the user object used in a feature flag evaluation                                 | false    | `ld-github-action-flags`          |
-| `base-uri`   | The base URI for the LaunchDarkly server. Most users should use the default value.           | false    | `https://app.launchdarkly.com`    |
-| `events-uri` | The base URI for the LaunchDarkly events server. Most users should use the default value.    | false    | `https://events.launchdarkly.com` |
-| `stream-uri` | The base URI for the LaunchDarkly streaming server. Most users should use the default value. | false    | `https://stream.launchdarkly.com` |
+| Option         | Description                                                                                                                 | Required | Default value                     |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
+| `sdk-key`      | SDK Key for environment                                                                                                     | true     |                                   |
+| `flag-keys`    | The flag keys to evaluate                                                                                                   | true     |                                   |
+| `user-key`     | The key of the user object used in a feature flag evaluation                                                                | false    | `ld-github-action-flags`          |
+| `base-uri`     | The base URI for the LaunchDarkly server. Most users should use the default value.                                          | false    | `https://app.launchdarkly.com`    |
+| `events-uri`   | The base URI for the LaunchDarkly events server. Most users should use the default value.                                   | false    | `https://events.launchdarkly.com` |
+| `stream-uri`   | The base URI for the LaunchDarkly streaming server. Most users should use the default value.                                | false    | `https://stream.launchdarkly.com` |
+| `proxy-auth`   | Allows you to specify basic authentication parameters for an optional HTTP proxy. Usually of the form `username:password`.  | false    |                                   |
+| `proxy-host`   | Allows you to specify a host for an optional HTTP proxy. Both the host and port must be specified to enable proxy support.  | false    |                                   |
+| `proxy-port`   | Allows you to specify a port for an optional HTTP proxy. Both the host and port` must be specified to enable proxy support. | false    |                                   |
+| `proxy-scheme` | When using an HTTP proxy, specifies whether it is accessed via `http` or `https`                                            | false    |                                   |
 
 ## Output
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'The flag keys to evaluate.'
     required: true
     default: ''
+  user-key:
+    description: 'The key of the user object used in a feature flag evaluation'
+    required: false
+    default: 'ld-github-action-flags'
   base-uri:
     description: 'The base URI for the LaunchDarkly server. Most users should use the default value.'
     required: false
@@ -24,13 +28,21 @@ inputs:
     required: false
     default: 'https://stream.launchdarkly.com'
   events-uri:
-    description: 'The base URI for the LaunchDarkly events server. Most users should use the default value.'
+    description: The base URI for the LaunchDarkly events server. Most users should use the default value.
     required: false
     default: 'https://events.launchdarkly.com'
-  user-key:
-    description: 'The key of the user object used in a feature flag evaluation.'
+  proxy-auth:
+    description: 'Allows you to specify basic authentication parameters for an optional HTTP proxy. Usually of the form username:password.'
     required: false
-    default: 'ld-github-action-flags'
+  proxy-host:
+    description: 'Allows you to specify a host for an optional HTTP proxy. Both the host and port must be specified to enable proxy support.'
+    required: false
+  proxy-port:
+    description: 'Allows you to specify a port for an optional HTTP proxy. Both the host and port must be specified to enable proxy support.'
+    required: false
+  proxy-scheme:
+    description: 'When using an HTTP proxy, specifies whether it is accessed via http or https'
+    required: false
 
 # Outputs are generated dynamically based on the flag-keys you supply
 # outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -16304,10 +16304,15 @@ const main = async () => {
   const sdkKey = core.getInput('sdk-key');
   core.setSecret(sdkKey);
   const flagKeys = core.getMultilineInput('flag-keys');
+  const userKey = core.getInput('user-key');
   const baseUri = core.getInput('base-uri');
   const eventsUri = core.getInput('events-uri');
   const streamUri = core.getInput('stream-uri');
-  const userKey = core.getInput('user-key');
+  // these will be validated by SDK
+  const proxyAuth = core.getInput('proxy-auth');
+  const proxyHost = core.getInput('proxy-host');
+  const proxyPort = core.getInput('proxy-port');
+  const proxyScheme = core.getInput('proxy-scheme');
 
   core.info(baseUri);
   const validationErrors = validate({ sdkKey, flagKeys });
@@ -16336,8 +16341,27 @@ const main = async () => {
     });
   core.endGroup();
 
+  const options = {
+    baseUri,
+    eventsUri,
+    streamUri,
+  };
+
+  if (proxyAuth) {
+    options.proxyAuth = proxyAuth;
+  }
+  if (proxyHost) {
+    options.proxyHost = proxyHost;
+  }
+  if (proxyPort) {
+    options.proxyPort = proxyPort;
+  }
+  if (proxyScheme) {
+    options.proxyScheme = proxyScheme;
+  }
+
   // evaluate flags
-  const client = new LDClient(sdkKey, { baseUri, eventsUri, streamUri }, userKey);
+  const client = new LDClient(sdkKey, options, userKey);
   core.startGroup('Evaluating flags');
   const flags = await client.evaluateFlags(flagKeys, ctx);
   await client.flush();

--- a/index.js
+++ b/index.js
@@ -8,10 +8,15 @@ const main = async () => {
   const sdkKey = core.getInput('sdk-key');
   core.setSecret(sdkKey);
   const flagKeys = core.getMultilineInput('flag-keys');
+  const userKey = core.getInput('user-key');
   const baseUri = core.getInput('base-uri');
   const eventsUri = core.getInput('events-uri');
   const streamUri = core.getInput('stream-uri');
-  const userKey = core.getInput('user-key');
+  // these will be validated by SDK
+  const proxyAuth = core.getInput('proxy-auth');
+  const proxyHost = core.getInput('proxy-host');
+  const proxyPort = core.getInput('proxy-port');
+  const proxyScheme = core.getInput('proxy-scheme');
 
   core.info(baseUri);
   const validationErrors = validate({ sdkKey, flagKeys });
@@ -40,8 +45,27 @@ const main = async () => {
     });
   core.endGroup();
 
+  const options = {
+    baseUri,
+    eventsUri,
+    streamUri,
+  };
+
+  if (proxyAuth) {
+    options.proxyAuth = proxyAuth;
+  }
+  if (proxyHost) {
+    options.proxyHost = proxyHost;
+  }
+  if (proxyPort) {
+    options.proxyPort = proxyPort;
+  }
+  if (proxyScheme) {
+    options.proxyScheme = proxyScheme;
+  }
+
   // evaluate flags
-  const client = new LDClient(sdkKey, { baseUri, eventsUri, streamUri }, userKey);
+  const client = new LDClient(sdkKey, options, userKey);
   core.startGroup('Evaluating flags');
   const flags = await client.evaluateFlags(flagKeys, ctx);
   await client.flush();


### PR DESCRIPTION
Allows `proxy` prefixed [LDOptions](https://launchdarkly.github.io/node-server-sdk/interfaces/_launchdarkly_node_server_sdk_.LDOptions.html#proxyAuth). Leave validation to SDK