### PR TITLE
Change hard-coded context key

### DIFF
--- a/action.js
+++ b/action.js
@@ -52,7 +52,7 @@ export const run = async () => {
   const githubCtx = process.env[githubKey]
     ? {
         Github: {
-          key: process.env[githubKey] ? process.env[githubKey].split('/')[-1].trim() : process.env['GITHUB_RUN_ID'],
+          key: process.env[githubKey] ? process.env[githubKey].split('/').pop().trim() : process.env['GITHUB_RUN_ID'],
           ...createContext(envGithubFilters, githubKey),
         },
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -17202,7 +17202,7 @@ const run = async () => {
   const githubCtx = process.env[githubKey]
     ? {
         Github: {
-          key: process.env[githubKey] ? process.env[githubKey].split('/')[-1].trim() : process.env['GITHUB_RUN_ID'],
+          key: process.env[githubKey] ? process.env[githubKey].split('/').pop().trim() : process.env['GITHUB_RUN_ID'],
           ...createContext(envGithubFilters, githubKey),
         },
       }


### PR DESCRIPTION
The `Github` context had a hard-coded key of `test` because the preferred method of passing in the `GITHUB_REPOSITORY` env var to the key causes the context to not be viewable in the UI due to forward slashes in the URL. This PR modifies the value to only use the repo name. The organization is still available under the `GITHUB_ORGANIZATION` value.