### PR TITLE
fix: Await flush to ensure events are sent on shutdown

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31423,7 +31423,7 @@ var LDClient = class {
     this.client.close();
   }
   async flush() {
-    this.client.flush();
+    await this.client.flush();
   }
   async evaluateFlag(flagKey, ctx, defaultValue) {
     var timeout = null;

--- a/src/client.js
+++ b/src/client.js
@@ -12,7 +12,7 @@ export default class LDClient {
   }
 
   async flush() {
-    this.client.flush();
+    await this.client.flush();
   }
 
   async evaluateFlag(flagKey, ctx, defaultValue) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -83,4 +83,37 @@ describe('Action', () => {
     expect(core.setOutput).toHaveBeenNthCalledWith(2, 'flag-key-2', false);
     expect(core.setOutput).toHaveBeenNthCalledWith(3, 'flag-key-3', false);
   });
+
+  test('flush() completes before close() is called', async () => {
+    let flushResolved = false;
+    const mockFlush = vi.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          flushResolved = true;
+          resolve();
+        }, 10);
+      });
+    });
+
+    const mockClose = vi.fn().mockImplementation(() => {
+      // If flush wasn't awaited, this would be called before flushResolved is true
+      expect(flushResolved).toBe(true);
+    });
+
+    vi.spyOn(LaunchDarkly, 'init').mockReturnValue({
+      variation: vi.fn().mockResolvedValue(false),
+      waitForInitialization: vi.fn().mockResolvedValue(),
+      flush: mockFlush,
+      close: mockClose,
+    });
+
+    const exitCode = await runAction({
+      'sdk-key': 'sdk-xxxx',
+      flags: 'flag-key',
+    });
+    expect(exitCode).toBe(0);
+    expect(mockFlush).toHaveBeenCalledOnce();
+    expect(mockClose).toHaveBeenCalledOnce();
+    expect(flushResolved).toBe(true);
+  });
 });


### PR DESCRIPTION
fixes #80 